### PR TITLE
wicked-migrate: add POC tests for wicked migration 2 NetworkManger

### DIFF
--- a/lib/wicked/nm_migrate.pm
+++ b/lib/wicked/nm_migrate.pm
@@ -1,0 +1,58 @@
+package wicked::nm_migrate;
+
+use Mojo::Base 'wickedbase';
+use utils qw(zypper_call systemctl);
+
+use testapi;
+
+has container_image => "registry.opensuse.org/home/jcronenberg/migrate-wicked/containers/opensuse/migrate-wicked-git:latest";
+has container_engine_cmd => undef;
+
+sub migrate
+{
+    my ($self) = @_;
+
+    record_info("xmlcfg", script_output('wicked show-config'));
+
+    my $args = "";
+    $args .= "-e MIGRATE_WICKED_CONTINUE_MIGRATION=true " if get_var("WICKED_NM_MIGRATE_CONTINUE_ON_FAILURE");
+
+    assert_script_run(sprintf('%s run %s -v /etc/sysconfig/network:/etc/sysconfig/network "%s"', $self->container_runtime, $args, $self->container_image));
+
+    record_info("MIGRATED", script_output('for i in /etc/sysconfig/network/NM-migrated/*; do echo "### $i"; cat $i; echo ""; done;'));
+
+    systemctl("enable --force NetworkManager");
+
+    $self->reboot();
+}
+
+sub assert_nm_state
+{
+    my ($self, %args) = @_;
+
+    if ($args{ping_ip}) {
+        $self->ping_with_timeout(ip => $args{ping_ip}, interface => $args{iface});
+    }
+
+    assert_script_run(sprintf("grep -q '%s' /sys/class/net/%s/operstate", $args{interfaces_down} ? 'down' : 'up', $args{iface}));
+
+}
+
+sub before_test
+{
+    my $self = shift // wicked::nm_migrate->new();
+
+    $self->prepare_containers();
+
+    assert_script_run(sprintf('%s pull "%s"', $self->container_runtime, $self->container_image));
+    zypper_call('-q in NetworkManager');
+
+    # Check  that NetworkManager isn't active
+    systemctl('is-active NetworkManager', expect_false => 1);
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -19,6 +19,7 @@ use serial_terminal;
 use main_common 'is_updates_tests';
 use repo_tools 'generate_version';
 use wicked::wlan;
+use wicked::nm_migrate;
 use mm_network;
 use power_action_utils 'power_action';
 
@@ -83,7 +84,7 @@ EOT
         }
         file_content_replace('/etc/sysconfig/dhcpd', '--sed-modifier' => 'g', '^DHCPD_INTERFACE=.*' => 'DHCPD_INTERFACE="' . $ctx->iface() . '"');
 
-        if (check_var('WICKED', 'basic')) {
+        if (check_var('WICKED', 'basic') || check_var('WICKED', 'nm_migrate_basic')) {
             $self->prepare_containers();
         }
 
@@ -165,6 +166,7 @@ EOT
             }
         }
         wicked::wlan::prepare_packages() if (check_var('WICKED', 'wlan'));
+        wicked::nm_migrate::before_test() if (get_var('WICKED', '') =~ /^nm_migrate_/);
 
         if ($self->valgrind_enable()) {
             $need_reboot = 1;

--- a/tests/wicked/nm_migrate_basic/sut/t02_static_addresses_legacy.pm
+++ b/tests/wicked/nm_migrate_basic/sut/t02_static_addresses_legacy.pm
@@ -1,0 +1,25 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: wicked 2 NetworkManger migration
+# Summary: Set up static addresses from legacy ifcfg files
+# Maintainer: Clemens Famulla-Conrad <cfamullaconrad@suse.de>
+
+use Mojo::Base 'wicked::nm_migrate';
+use testapi;
+
+sub run {
+    my ($self, $ctx) = @_;
+
+    my $cfg = '/etc/sysconfig/network/ifcfg-' . $ctx->iface();
+    $self->get_from_data('wicked/static_address/ifcfg-eth0', $cfg);
+    record_info("ifcfg", script_output("cat '$cfg'"));
+    $self->wicked_command('ifup', $ctx->iface());
+
+    $self->migrate();
+    $self->assert_nm_state(ping_ip => $self->get_remote_ip(type => 'host'), iface => $ctx->iface());
+}
+
+1;

--- a/tests/wicked/nm_migrate_basic/sut/t04_dynamic_addresses_legacy.pm
+++ b/tests/wicked/nm_migrate_basic/sut/t04_dynamic_addresses_legacy.pm
@@ -1,0 +1,26 @@
+# SUSE's openQA tests
+#
+# Copyright 2024 SUSE LLC
+# SPDX-License-Identifier: FSFAP
+
+# Package: wicked 2 NetworkManger migration
+# Summary: Set up dynamic addresses from legacy ifcfg files
+# Maintainer: Clemens Famulla-Conrad <cfamullaconrad@suse.de>
+
+
+use Mojo::Base 'wicked::nm_migrate';
+use testapi;
+
+sub run {
+    my ($self, $ctx) = @_;
+
+    my $cfg = '/etc/sysconfig/network/ifcfg-' . $ctx->iface();
+    $self->get_from_data('wicked/dynamic_address/ifcfg-eth0', $cfg);
+    record_info("ifcfg", script_output("cat '$cfg'"));
+    $self->wicked_command('ifup', $ctx->iface());
+
+    $self->migrate();
+    $self->assert_nm_state(ping_ip => $self->get_remote_ip(type => 'host'), iface => $ctx->iface());
+}
+
+1;


### PR DESCRIPTION
This is a POC for wicked2NetworkManager migration tests. It use the same configuration as used in the corresponding wicked tests and then calling the migration tool and verify NetworkManager to operate on the generated configs.

For now, we pass the `--continue` argument to `migrate-wicked` tool. This allow none fatal errors to be ignored.
Can be disabled with `WICKED_NM_MIGRATE_CONTINUE_ON_FAILURE=0`

The migration tool is in the `registry.opensuse.org/home/jcronenberg/migrate-wicked/containers/opensuse/migrate-wicked-git:latest` container. The code is here https://github.com/jcronenberg/agama for now.

Trigger these job with:
```bash
host=https://openqa.suse.de
hdd=sle_15_sp6.qcow2
uefi=sle_15_sp6-uefi-vars.qcow2

openqa-cli api --host $host -X POST jobs 'ARCH:1=x86_64' 'ARCH:2=x86_64' 'BACKEND:1=qemu' 'BACKEND:2=qemu' 'BOOT_HDD_IMAGE:1=1' 'BOOT_HDD_IMAGE:2=1' 'BUILD:1=No-Branch' 'BUILD:2=No-Branch' 'CASEDIR:1=https://github.com/cfconrad/os-autoinst-distri-opensuse#poc_wicked_migration' 'CASEDIR:2=https://github.com/cfconrad/os-autoinst-distri-opensuse#poc_wicked_migration' 'DESKTOP:1=textmode' 'DESKTOP:2=textmode' 'DISTRI:1=sle' 'DISTRI:2=sle' 'EXTRATEST:1=wicked' 'EXTRATEST:2=wicked' 'FLAVOR:1=CI' 'FLAVOR:2=CI' 'HDDSIZEGB:1=30' 'HDDSIZEGB:2=30' "HDD_1:1=$hdd" "HDD_1:2=$hdd" 'IS_WICKED_REF:1=1' 'KEEP_GRUB_TIMEOUT:1=1' 'KEEP_GRUB_TIMEOUT:2=1' 'MACHINE:1=x86_64' 'MACHINE:2=x86_64' 'NICTYPE:1=tap' 'NICTYPE:2=tap' 'NOIMAGES:1=1' 'NOIMAGES:2=1' 'NOVIDEO:1=1' 'NOVIDEO:2=1' 'OVS_DEBUG:1=1' 'OVS_DEBUG:2=1' 'PARALLEL_WITH:2=wicked_nm_migrate_basic_ref' 'QEMUCPU:1=qemu64' 'QEMUCPU:2=qemu64' 'QEMUVGA:1=cirrus' 'QEMUVGA:2=cirrus' 'TAPDEV:1=auto,auto' 'TAPDEV:2=auto,auto' 'TEST:1=wicked_nm_migrate_basic_ref' 'TEST:2=wicked_nm_migrate_basic_sut' "UEFI_PFLASH_VARS:1=$uefi" "UEFI_PFLASH_VARS:2=$uefi" 'VERSION:1=15-SP6' 'VERSION:2=15-SP6' 'VIDEOMODE:1=text' 'VIDEOMODE:2=text' 'VIRTIO_CONSOLE:1=1' 'VIRTIO_CONSOLE:2=1' 'VIRTIO_CONSOLE_NUM:1=2' 'VIRTIO_CONSOLE_NUM:2=2' 'WICKED_NM_MIGRATE_CONTINUE_ON_FAILURE:1=1' 'WICKED_NM_MIGRATE_CONTINUE_ON_FAILURE:2=1' 'WICKED:1=nm_migrate_basic' 'WICKED:2=nm_migrate_basic' 'WICKED_CHECK_LOG_FAIL:1=1' 'WICKED_CHECK_LOG_FAIL:2=1' 'WICKED_NEED_NETWORK_TWEAKS:1=0' 'WICKED_NEED_NETWORK_TWEAKS:2=0' 'WORKER_CLASS:1=tap,qemu_x86_64' 'WORKER_CLASS:2=tap,qemu_x86_64' '_GROUP_ID:1=29' '_GROUP_ID:2=29' '_PARALLEL:2=1' '_QUIET_SCRIPT_CALLS:1=1' '_QUIET_SCRIPT_CALLS:2=1'
```

- Related ticket: TBD
- Verification run: http://openqa.wicked.suse.de/t179390
